### PR TITLE
Fix hashable_cache decorator

### DIFF
--- a/EasyTSAD/Evaluations/Protocols/VUS.py
+++ b/EasyTSAD/Evaluations/Protocols/VUS.py
@@ -493,7 +493,7 @@ class metricor:
         )
 
 
-@hashable_cache()
+@hashable_cache
 def generate_curve(label, score, slidingWindow):
     (
         tpr_3d,


### PR DESCRIPTION
The parenthesis trigger an error, saying function argument is missing.

```
Traceback (most recent call last):
  File "/home/evann/dev/EasyTSAD/Examples/run_baseline/run.py", line 53, in <module>
    from EasyTSAD.Evaluations.Protocols import EventF1PA, PointF1PA
  File "/home/evann/dev/EasyTSAD/EasyTSAD/Evaluations/Protocols/__init__.py", line 14, in <module>
    from .VUS import VUS_ROC, VUS_PR, R_AP, R_AUC
  File "/home/evann/dev/EasyTSAD/EasyTSAD/Evaluations/Protocols/VUS.py", line 496, in <module>
    @hashable_cache()
     ^^^^^^^^^^^^^^^^
TypeError: hashable_cache() missing 1 required positional argument: 'func'
```